### PR TITLE
Support gnome-system-monitor 46

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -2500,11 +2500,8 @@ export default class SystemMonitorExtension extends Extension {
             );
 
             let _appSys = Shell.AppSystem.get_default();
-            let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
-            let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
-            if (_gsmPrefs === null) {
-                _gsmPrefs = _appSys.lookup_app('org.gnome.Extensions.desktop');
-            }
+            let _gsmApp = _appSys.lookup_app('org.gnome.SystemMonitor.desktop') || _appSys.lookup_app('gnome-system-monitor.desktop');
+
             let item;
             item = new PopupMenu.PopupMenuItem(_('System Monitor...'));
             item.connect('activate', () => {


### PR DESCRIPTION
The launcher filename has changed in GNOME 46.

Also drops the unused extensions app lookup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-applet/62)
<!-- Reviewable:end -->
