### PR TITLE
Fix tooltip text being garbled/blurry sometimes due to fractional x position

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -706,6 +706,7 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
         let tipx = cx - width / 2;
         tipx = Math.max(tipx, monitor.x);
         tipx = Math.min(tipx, monitor.x + monitor.width - width);
+        tipx = Math.floor(tipx);
         let tipy = Math.floor(ym);
         // Hacky condition to determine if the status bar is at the top or at the bottom of the screen
         if (sourceTopLeftY / monitor.height > 0.3) {


### PR DESCRIPTION
Copy of https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/779. I think it makes sense to abandon upstream, given how long it's been without us being full given access to everything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-applet/70)
<!-- Reviewable:end -->
