### PR TITLE
GPU: Un-hardcode /bin/bash location

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -2161,7 +2161,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
         // Run asynchronously, to avoid shell freeze
         try {
             let path = this.extension.path;
-            let script = ['/bin/bash', path + '/gpu_usage.sh'];
+            let script = ['/usr/bin/env', 'bash', path + '/gpu_usage.sh'];
 
             // Create subprocess and capture STDOUT
             let proc = new Gio.Subprocess({argv: script, flags: Gio.SubprocessFlags.STDOUT_PIPE});


### PR DESCRIPTION
### What I tested

- [x] Verified no regressions to existing functionality.
  It is assumed there's no side-effects in this change, so I did no regression tests as they're not needed.
- [x] Tested on the following Gnome Shell versions: 45.5, 46.1

### Changes

This PR changes hardcoded /bin/bash to /usr/bin/env bash in GPU module, fixing non-working GPU module for non-FHS distributions such as NixOS.

Actually tested with direct patch to NixOS package, but this PR is so small it doesn't need throrough testing.

<details>
<summary>The NixOS override I use for now</summary>

```nix
{gnomeExtensions}: gnomeExtensions.system-monitor-next.overrideAttrs (old: {
  patches = old.patches ++ [
    ./usr-bin-env.patch
  ];
})
```

Mentioned patch is (the same as in this PR):

```diff
--- a/extension.js
+++ b/extension.js
@@ -2161,7 +2161,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
         // Run asynchronously, to avoid shell freeze
         try {
             let path = this.extension.path;
-            let script = ['/bin/bash', path + '/gpu_usage.sh'];
+            let script = ['/usr/bin/env', 'bash', path + '/gpu_usage.sh'];

             // Create subprocess and capture STDOUT
             let proc = new Gio.Subprocess({argv: script, flags: Gio.SubprocessFlags.STDOUT_PIPE});
```

</details>

Also tested this patch on Arch Linux (FHS distribution) - GPU module works as expected.

Warning: I did not test this patch on master branch, I did only on latest (66) version from e.g.o

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-applet/74)
<!-- Reviewable:end -->
