### PR TITLE
Fix common.js missing from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ INSTALLNAME = $(UUID)
 
 BASE_MODULES = \
   $(UUID)/extension.js \
+  $(UUID)/common.js \
   $(UUID)/README* \
   $(UUID)/metadata.json \
   $(UUID)/prefs.js \


### PR DESCRIPTION
Resolves https://github.com/mgalgs/gnome-shell-system-monitor-applet/issues/75.

Not tested, but I did verify that the zip file now includes `common.js`:

```
➜ make zip-file
  [build.clean ] OK
  [gschemas    ] OK
  [extension   ] OK
  [translate   ] ar/ ca/ cs/ de/ es_ES/ es_MX/ fa/ fi/ fr/ hu/ it/ ja/ ko/ nl_NL/ pl/ pt/ pt_BR/ ro/ ru/ sk/ tr/ uk/ zh_CN/ 
  [translate   ] OK
  [build       ] OK
  [zip-file    ] OK

➜ unzip -l dist/system-monitor-next@paradoxxx.zero.gmail.com.zip | grep common
     2829  2024-05-03 19:30   common.js
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-applet/76)
<!-- Reviewable:end -->
