### PR TITLE
Battery indicator fix

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -1134,6 +1134,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
     constructor(extension) {
         super(extension, {
             elt: 'battery',
+            elt_short: 'batt',
             item_name: _('Battery'),
             color_name: ['batt0'],
             icon: '. GThemedIcon battery-good-symbolic battery-good'


### PR DESCRIPTION
This is fork to fix the battery indicator by waiting for Main.panel.statusArea.quickSettings._system._systemItem._powerToggle._proxy to exist before trying to read it. This broke a few gnome versions ago when a race condition was exposed by the dynamic creation of these gnome properties.

### What I tested

- [X ] Verified no regressions to existing functionality.
- [X] Tested on the following Gnome Shell versions: (list them here): 47, 48, 49

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/128)
<!-- Reviewable:end -->
