### PR TITLE
Gnome Shell 50

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "uuid": "system-monitor-next@paradoxxx.zero.gmail.com",
     "name": "system-monitor-next",
     "url": "https://github.com/mgalgs/gnome-shell-system-monitor-next-applet",


### PR DESCRIPTION
### What I tested

- [x] Verified no regressions to existing functionality.
- [x] Tested on the following Gnome Shell versions: GNOME Shell 50.beta

### Screenshots

<img width="649" height="40" alt="Screenshot From 2026-03-18 16-18-59" src="https://github.com/user-attachments/assets/df356877-1ad1-4f02-a7de-214c4e0c12d3" />

All is working good.

Not related to this pull but interesting:
Look what ChatGPT is saying about migration.js file:

Unused import
import Gio from "gi://Gio";

👉 You’re not actually using Gio here.

Not harmful

But you could remove it for cleanliness

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/137)
<!-- Reviewable:end -->
