### PR TITLE
widgets: Make UI consistent

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
@@ -6,7 +6,9 @@ import GTop from "gi://GTop";
 import St from "gi://St";
 import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 import { sm_log } from './utils.js';
-import { color_from_string, sm_cairo_set_source_color } from './base.js';
+
+// Visual distinction between adjacent mount rings/bars; cycled per index.
+const MOUNT_SHADE_ALPHAS = [1.0, 0.7, 0.5];
 
 // stale network shares will cause the shell to freeze, enable this with caution
 export const ENABLE_NETWORK_DISK_USAGE = false;
@@ -179,10 +181,6 @@ export const Graph = class SystemMonitor_Graph {
         this.width = width;
         this.height = height;
         this.gtop = new GTop.glibtop_fsusage();
-        this.colors = ['#888', '#aaa', '#ccc'];
-        for (let color in this.colors) {
-            this.colors[color] = color_from_string(this.colors[color]);
-        }
 
         let themeContext = St.ThemeContext.get_for_stage(global.stage);
         themeContext.connect('notify::scale-factor', this.set_scale.bind(this));
@@ -244,11 +242,13 @@ export const Bar = class SystemMonitor_Bar extends Graph {
         let y0 = thickness / 2;
         cr.setLineWidth(thickness);
         cr.setFontSize(fontsize);
+        const fg = this.actor.get_theme_node().get_foreground_color();
         for (let mount in this.mounts) {
             GTop.glibtop_get_fsusage(this.gtop, this.mounts[mount]);
             const {used, total} = calc_usage(this.gtop);
             const perc_full = used / total;
-            sm_cairo_set_source_color(cr, this.colors[mount % this.colors.length]);
+            const alpha = MOUNT_SHADE_ALPHAS[mount % MOUNT_SHADE_ALPHAS.length];
+            cr.setSourceRGBA(fg.red / 255, fg.green / 255, fg.blue / 255, alpha);
 
             let text = this.mounts[mount];
             if (text.length > 10) {
@@ -311,10 +311,12 @@ export const Pie = class SystemMonitor_Pie extends Graph {
 
         cr.setLineWidth(thickness);
         cr.setFontSize(fontsize);
+        const fg = this.actor.get_theme_node().get_foreground_color();
         let r = (height - ring_width) / 2;
         for (let mount in this.mounts) {
             GTop.glibtop_get_fsusage(this.gtop, this.mounts[mount]);
-            sm_cairo_set_source_color(cr, this.colors[mount % this.colors.length]);
+            const alpha = MOUNT_SHADE_ALPHAS[mount % MOUNT_SHADE_ALPHAS.length];
+            cr.setSourceRGBA(fg.red / 255, fg.green / 255, fg.blue / 255, alpha);
             const {used, total} = calc_usage(this.gtop);
             arc(r, used, total, -pi / 2);
             cr.stroke();
@@ -322,6 +324,8 @@ export const Pie = class SystemMonitor_Pie extends Graph {
         }
         let y = (ring_width + fontsize) / 2;
         for (let mount in this.mounts) {
+            const alpha = MOUNT_SHADE_ALPHAS[mount % MOUNT_SHADE_ALPHAS.length];
+            cr.setSourceRGBA(fg.red / 255, fg.green / 255, fg.blue / 255, alpha);
             let text = this.mounts[mount];
             if (text.length > 10) {
                 text = text.split('/').pop();

--- a/system-monitor-next@paradoxxx.zero.gmail.com/stylesheet.css
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/stylesheet.css
@@ -4,14 +4,14 @@
 }
 
 .sm-label {
-    color: #bbb;
+    opacity: 0.75;
     font-size: 0.75em;
     padding-top: 5px;
     font-family: monospace;
 }
 
 .sm-label-left {
-    color: #bbb;
+    opacity: 0.75;
     font-size: 0.75em;
     padding: 5px 5px 0 0;
 }
@@ -24,7 +24,7 @@
 }
 
 .sm-status-label {
-    color: #bbb;
+    opacity: 0.75;
     font-size: 0.625em;
     padding: 0 2px 0 5px;
 }
@@ -35,13 +35,13 @@
 
 .sm-unit-label,
 .sm-net-unit-label {
-    color: #aaa;
+    opacity: 0.65;
     font-size: 0.5em;
     padding: 0 5px 0 2px;
 }
 
 .sm-disk-unit-label {
-    color: #aaa;
+    opacity: 0.65;
     font-size: 0.625em;
     padding: 0 5px 0 2px;
 }
@@ -51,13 +51,13 @@
 }
 
 .sm-perc-label {
-    color: #aaa;
+    opacity: 0.65;
     font-size: 0.625em;
     padding: 0 5px 0 2px;
 }
 
 .sm-temp-label {
-    color: #aaa;
+    opacity: 0.65;
     font-size: 0.6875em;
     padding: 0 5px 0 2px;
 }
@@ -115,7 +115,7 @@
 }
 
 .sm-label-compact {
-    color: #bbb;
+    opacity: 0.75;
     font-size: 0.6875em;
     font-family: monospace;
 } /* Bat, Net... units in menu items */
@@ -127,35 +127,35 @@
 } /* Values in menu items */
 
 .sm-status-label-compact {
-    color: #bbb;
+    opacity: 0.75;
     font-size: 0.5em;
     padding: 2px 0px 0 0px;
 } /* names and Disk R and W signs in text items */
 
 .sm-unit-label-compact,
 .sm-net-unit-label-compact {
-    color: #aaa;
+    opacity: 0.65;
     padding: 0 3px 0px 1px;
     text-align: right;
     font-size: 0.4375em;
 } /* Bat, Net... units in text items */
 
 .sm-disk-unit-label-compact {
-    color: #aaa;
+    opacity: 0.65;
     padding: 0 3px 0px 0px;
     text-align: right;
     font-size: 0.4375em;
 } /* Disk units in text items */
 
 .sm-perc-label-compact {
+    opacity: 0.65;
     padding: 0 3px 0 0px;
-    color: #aaa;
     font-size: 0.5em;
 } /* Cpu, Mem ... % sign in text items */
 
 .sm-temp-label-compact {
+    opacity: 0.65;
     font-size: 0.625em;
-    color: #aaa;
     padding: 0 1px 0 1px;
 } /* Thermal °C sign in text items */
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
@@ -11,7 +11,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         name: 'Freq',
         metrics: [{ key: 'freq', color: true }],
         tooltipUnit: 'MHz',
-        panelUnit: 'MHz',
+        panelUnit: ' MHz',
         menuUnit: 'MHz',
         panelValueStyle: 'sm-big-status-value',
         panelUnitStyle: 'sm-perc-label',

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
@@ -25,7 +25,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
 
         this.item_name = _('GPU') + (this.gpu_index !== '0' ? ' ' + this.gpu_index : '');
         if (this.gpu_index !== '0')
-            this.label.text = _('GPU') + this.gpu_index;
+            this.label.text = 'gpu' + this.gpu_index;
     }
 
     collectAsync(callback) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
@@ -79,7 +79,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
     }
 
     reset_style() {
-        this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
+        this.text_items[0].set_style(null);
     }
 
     threshold() {
@@ -87,7 +87,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             if (this.temp_over_threshold)
                 this.text_items[0].set_style('color: rgba(255, 0, 0, 1)');
             else
-                this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
+                this.text_items[0].set_style(null);
         }
     }
 


### PR DESCRIPTION
### What I tested

- [x] Verified no regressions to existing functionality.
- [x] Tested on the following Gnome Shell versions: 50

### Screenshots
original: 
<img width="927" height="45" alt="Screenshot From 2026-05-25 13-54-32" src="https://github.com/user-attachments/assets/c24e86f1-268f-4e5b-bb61-efd94e3bd4c3" />

add space to MHz, lower case all gpu labels:
<img width="931" height="50" alt="Screenshot From 2026-05-25 13-52-15" src="https://github.com/user-attachments/assets/47329da2-b2b5-4093-8341-74ed6313add6" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/148)
<!-- Reviewable:end -->
