### PR TITLE
mounts: Never block the shell on mount probes

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
@@ -357,7 +357,10 @@ export const Bar = class SystemMonitor_Bar extends Graph {
         for (let mount in this.mounts) {
             GTop.glibtop_get_fsusage(this.gtop, this.mounts[mount]);
             const {used, total} = calc_usage(this.gtop);
-            const perc_full = used / total;
+            // A mount we cannot size reports zero blocks. Dividing by that
+            // yields NaN, and NaN coordinates put the Cairo context into a
+            // permanent error state.
+            const perc_full = total > 0 ? used / total : 0;
             const alpha = MOUNT_SHADE_ALPHAS[mount % MOUNT_SHADE_ALPHAS.length];
             cr.setSourceRGBA(fg.red / 255, fg.green / 255, fg.blue / 255, alpha);
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
@@ -333,11 +333,21 @@ export const Bar = class SystemMonitor_Bar extends Graph {
         if (!this.actor.visible) {
             return;
         }
+        let cr = this.actor.get_context();
+        try {
+            this._paint(cr);
+        } finally {
+            // Anything thrown while painting would otherwise leave the context
+            // undisposed. The compositor repaints continuously, so one leak
+            // becomes a leak per frame.
+            cr.$dispose();
+        }
+    }
+    _paint(cr) {
         let thickness = this.extension._Style.bar_thickness() * this.scale_factor * this.text_scaling;
         let fontsize = this.extension._Style.bar_fontsize() * this.scale_factor * this.text_scaling;
         this.actor.set_height(this.mounts.length * (3 * thickness));
         let [width, _height] = this.actor.get_surface_size();
-        let cr = this.actor.get_context();
 
         let x0 = width / 8;
         let y0 = thickness / 2;
@@ -366,7 +376,6 @@ export const Bar = class SystemMonitor_Bar extends Graph {
             cr.stroke();
             y0 += (7 * thickness) / 4;
         }
-        cr.$dispose();
     }
     update_mounts(mounts) {
         this.mounts = mounts;
@@ -390,8 +399,18 @@ export const Pie = class SystemMonitor_Pie extends Graph {
         if (!this.actor.visible) {
             return;
         }
-        let [width, height] = this.actor.get_surface_size();
         let cr = this.actor.get_context();
+        try {
+            this._paint(cr);
+        } finally {
+            // Anything thrown while painting would otherwise leave the context
+            // undisposed. The compositor repaints continuously, so one leak
+            // becomes a leak per frame.
+            cr.$dispose();
+        }
+    }
+    _paint(cr) {
+        let [width, height] = this.actor.get_surface_size();
         let xc = width / 2;
         let yc = height / 2;
         let pi = Math.PI;
@@ -440,7 +459,6 @@ export const Pie = class SystemMonitor_Pie extends Graph {
             cr.showText(text);
             y += ring_width;
         }
-        cr.$dispose();
     }
 
     update_mounts(mounts) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
@@ -2,6 +2,7 @@
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import Gio from "gi://Gio";
+import GLib from "gi://GLib";
 import GTop from "gi://GTop";
 import St from "gi://St";
 import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
@@ -12,6 +13,17 @@ const MOUNT_SHADE_ALPHAS = [1.0, 0.7, 0.5];
 
 // stale network shares will cause the shell to freeze, enable this with caution
 export const ENABLE_NETWORK_DISK_USAGE = false;
+
+// Filesystem types we cannot usefully statfs() for a disk usage figure.
+const NET_FILESYSTEMS = ['nfs', 'smbfs', 'cifs', 'ftp', 'sshfs', 'sftp', 'mtp', 'mtpfs'];
+
+// Attaching one device emits several mount signals. Wait this long for the
+// burst to end so we probe once instead of once per signal.
+const REFRESH_DEBOUNCE_MS = 300;
+
+// How long a mount gets to answer before we publish the list without it. A
+// healthy mount answers in microseconds; anything near this limit is wedged.
+const PROBE_TIMEOUT_MS = 5000;
 
 export function interesting_mountpoint(mount) {
     if (mount.length < 3) {
@@ -51,49 +63,125 @@ export const smMountsMonitor = class SystemMonitor_smMountsMonitor {
                 this.base_mounts.push(sMount);
             }
         });
+        // refresh() publishes asynchronously, so seed the list here. Widgets
+        // read get_mounts() in their own constructors and must never see undefined.
+        this.mounts = [...this.base_mounts];
+        this._refreshId = null;
+        this._probeTimeoutId = null;
+        this._probeCancellable = null;
+        this._probeGen = 0;
         this.startListening();
     }
     refresh() {
-        // try check that number of volumes has changed
-        // try {
-        //     let num_mounts = this.manager.getMounts().length;
-        //     if (num_mounts == this.num_mounts)
-        //         return;
-        //     this.num_mounts = num_mounts;
-        // } catch (e) {};
-
         // Can't get mountlist:
         // GTop.glibtop_get_mountlist
         // Error: No symbol 'glibtop_get_mountlist' in namespace 'GTop'
-        // Getting it with mtab
-        // let mount_lines = Shell.get_file_contents_utf8_sync('/etc/mtab').split("\n");
-        // this.mounts = [];
-        // for(let mount_line in mount_lines) {
-        //     let mount = mount_lines[mount_line].split(" ");
-        //     if(interesting_mountpoint(mount) && this.mounts.indexOf(mount[1]) < 0) {
-        //         this.mounts.push(mount[1]);
-        //     }
-        // }
-        // log("[System monitor] old mounts: " + this.mounts);
-        this.mounts = [];
-        for (let base in this.base_mounts) {
-            // log("[System monitor] " + this.base_mounts[base]);
-            this.mounts.push(this.base_mounts[base]);
+        // so the volume monitor is the source of truth.
+        //
+        // Attaching one device emits several mount signals in a row. Coalesce
+        // them, otherwise every signal starts its own round of probes.
+        if (this._refreshId) {
+            return;
         }
-        let mount_lines = this._volumeMonitor.get_mounts();
-        mount_lines.forEach((mount) => {
-            if ((!this.is_net_mount(mount) || ENABLE_NETWORK_DISK_USAGE) &&
-                 !this.is_ro_mount(mount)) {
-                let mpath = mount.get_root().get_path() || mount.get_default_location().get_path();
-                if (mpath) {
-                    this.mounts.push(mpath);
-                }
-            }
+        this._refreshId = GLib.timeout_add(GLib.PRIORITY_DEFAULT_IDLE, REFRESH_DEBOUNCE_MS, () => {
+            this._refreshId = null;
+            this._refreshAsync();
+            return GLib.SOURCE_REMOVE;
         });
-        // log("[System monitor] base: " + this.base_mounts);
-        // log("[System monitor] mounts: " + this.mounts);
+    }
+    // Build the mount list without ever blocking the caller. Every mount we
+    // still have to ask about gets an async query, so a wedged mount costs us a
+    // missing row in the disk popup instead of a frozen desktop.
+    _refreshAsync() {
+        this._cancelProbes();
+        // Cancelling does not stop the previous round's callbacks from running,
+        // it only makes them fail. Without this generation stamp the abandoned
+        // round would still reach settle() and publish its half-empty list over
+        // the results of this one.
+        const gen = this._probeGen;
+
+        const candidates = this._volumeMonitor.get_mounts().filter(
+            (mount) => ENABLE_NETWORK_DISK_USAGE || !this.is_gvfs_mount(mount));
+        if (!candidates.length) {
+            this._publish([]);
+            return;
+        }
+
+        // Keep results positional so the popup's row order stays stable
+        // regardless of which mount answers first.
+        const found = new Array(candidates.length).fill(null);
+        // found[i] === null also means "answered but unusable", so track
+        // answers separately: the timeout log must name only the mounts that
+        // actually stalled.
+        const answered = new Array(candidates.length).fill(false);
+        const cancellable = new Gio.Cancellable();
+        this._probeCancellable = cancellable;
+        let outstanding = candidates.length;
+        let settled = false;
+
+        const settle = () => {
+            if (settled || this._probeGen !== gen) {
+                return;
+            }
+            settled = true;
+            if (this._probeTimeoutId) {
+                GLib.Source.remove(this._probeTimeoutId);
+                this._probeTimeoutId = null;
+            }
+            if (this._probeCancellable === cancellable) {
+                this._probeCancellable = null;
+            }
+            this._publish(found.filter((mpath) => mpath !== null));
+        };
+
+        this._probeTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, PROBE_TIMEOUT_MS, () => {
+            this._probeTimeoutId = null;
+            const stuck = candidates.filter((mount, i) => !answered[i])
+                .map((mount) => mount.get_name()).join(', ');
+            sm_log(`mounts did not answer in time: ${stuck}; publishing without them`, 'warn');
+            cancellable.cancel();
+            settle();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        candidates.forEach((mount, i) => {
+            const file = mount.get_default_location();
+            file.query_filesystem_info_async(
+                `${Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE},${Gio.FILE_ATTRIBUTE_FILESYSTEM_READONLY}`,
+                GLib.PRIORITY_DEFAULT, cancellable, (source, result) => {
+                    answered[i] = true;
+                    try {
+                        const info = source.query_filesystem_info_finish(result);
+                        if (!settled && this.is_usable_mount(info)) {
+                            found[i] = mount.get_root().get_path() || file.get_path();
+                        }
+                    } catch {
+                        // Cancelled, or the mount cannot be read. Either way we
+                        // have no usable path, so leave this slot null rather
+                        // than pass an unknown path to glibtop_get_fsusage().
+                    }
+                    if (--outstanding === 0) {
+                        settle();
+                    }
+                });
+        });
+    }
+    _publish(extra_mounts) {
+        this.mounts = [...this.base_mounts, ...extra_mounts];
         for (let i in this.listeners) {
             this.listeners[i](this.mounts);
+        }
+    }
+    _cancelProbes() {
+        // Retires the current round: see the generation stamp in _refreshAsync().
+        this._probeGen++;
+        if (this._probeTimeoutId) {
+            GLib.Source.remove(this._probeTimeoutId);
+            this._probeTimeoutId = null;
+        }
+        if (this._probeCancellable) {
+            this._probeCancellable.cancel();
+            this._probeCancellable = null;
         }
     }
     add_listener(cb) {
@@ -120,29 +208,27 @@ export const smMountsMonitor = class SystemMonitor_smMountsMonitor {
             throw e;
         }
     }
-    is_ro_mount(mount) {
-        // FIXME: running this function after "login after waking from suspend"
-        // can make login hang. Actual issue seems to occur when a former net
-        // mount got broken (e.g. due to a VPN connection terminated or
-        // otherwise broken connection)
-        try {
-            let file = mount.get_default_location();
-            let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_READONLY, null);
-            return info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_FILESYSTEM_READONLY);
-        } catch {
-            return false;
-        }
+    // True for gvfs mounts: gphoto2, mtp, afc, sftp, smb and friends. Anything
+    // we would have to reach over gvfs is out of scope for a statfs() usage
+    // figure, and we must not even ask about it: the question is a round trip
+    // to gvfsd, which in turn talks to the device, and a device that does not
+    // answer — a locked phone, a dropped VPN — leaves that round trip hanging
+    // for the full D-Bus timeout. is_native() answers from local state alone,
+    // so this costs no IO and cannot stall.
+    is_gvfs_mount(mount) {
+        return !mount.get_default_location().is_native();
     }
-    is_net_mount(mount) {
-        try {
-            let file = mount.get_default_location();
-            let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE, null);
-            let result = info.get_attribute_string(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE);
-            let net_fs = ['nfs', 'smbfs', 'cifs', 'ftp', 'sshfs', 'sftp', 'mtp', 'mtpfs'];
-            return !file.is_native() || net_fs.indexOf(result) > -1;
-        } catch {
+    // Decide from an already-fetched GFileInfo, so this never performs IO.
+    is_usable_mount(info) {
+        if (info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_FILESYSTEM_READONLY)) {
             return false;
         }
+        if (ENABLE_NETWORK_DISK_USAGE) {
+            return true;
+        }
+        // Kernel-mounted network filesystems look native and have a real path,
+        // so only the reported type gives them away.
+        return NET_FILESYSTEMS.indexOf(info.get_attribute_string(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE)) === -1;
     }
     startListening() {
         if (this.connected) {
@@ -164,6 +250,14 @@ export const smMountsMonitor = class SystemMonitor_smMountsMonitor {
         this.refresh();
     }
     stopListening() {
+        // Drop the pending refresh and any in-flight probe first. Their
+        // callbacks outlive this object otherwise, and they would run against a
+        // disabled extension.
+        if (this._refreshId) {
+            GLib.Source.remove(this._refreshId);
+            this._refreshId = null;
+        }
+        this._cancelProbes();
         if (!this.connected) {
             return;
         }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/mounts.js
@@ -50,8 +50,6 @@ export function calc_usage(statfs) {
 // Class to deal with volumes insertion / ejection
 export const smMountsMonitor = class SystemMonitor_smMountsMonitor {
     constructor() {
-        this.files = [];
-        this.num_mounts = -1;
         this.listeners = [];
         this.connected = false;
 


### PR DESCRIPTION
## Summary

Fixes #133. #86 (closed) shares the mechanism.

`smMountsMonitor.refresh()` runs on the shell's main loop — on every `mount-added`/`mount-removed`, and at every `enable()`. Because the extension doesn't declare the `unlock-dialog` session mode, GNOME re-enables it at **every screen unlock**, so the probes also fire right in the unlock path. It made two synchronous `query_filesystem_info()` calls per mount. For a gvfs mount whose backend cannot answer — a locked phone exposed over gphoto2/MTP, a share behind a dropped VPN — each call stalls in gvfsd.

What "stalls" means differs by stack, and both are bad:

- **gvfs 1.60 / GNOME 50** (Arch): the sync call hard-blocks the compositor — measured ≥40 s with zero main-loop dispatch. enable-at-unlock → probe → block is exactly the "type the password, stare at a frozen screen for a minute" symptom in #133.
- **gvfs 1.54 / GNOME 46** (Ubuntu 24.04): the same call parks the calling frame in a nested main loop — a `refresh()` frame was measured suspended for **688 seconds** while the shell kept dispatching. Arbitrary events run under the suspended frame, including mount signals re-entering `refresh()` — a plausible route to the `corrupted double-linked list` SIGABRT crashes reported on Ubuntu in #86/#133.

`is_net_mount()` also failed open: when its probe threw, the mount was treated as local and its path handed to `glibtop_get_fsusage()` — a blocking `statfs()` — inside the Cairo repaint handlers.

## The fix

- `refresh()` is debounced (one probe round per mount-signal burst) and fully async.
- gvfs-vs-local is decided by `is_native()` alone — zero IO — and gvfs mounts are never queried at all.
- Remaining mounts get one combined `query_filesystem_info_async()` guarded by a `Gio.Cancellable`, a 5 s publish deadline (unresponsive mounts are dropped and named in the log), and a generation stamp so a superseded round cannot publish over a newer one.
- Probes are cancelled in `stopListening()`; Cairo contexts are disposed in `finally`; zero-block mounts can no longer produce NaN geometry.

No synchronous gvfs call remains in the extension.

## Repro (no phone needed)

```bash
gio mount sftp://localhost/
kill -STOP $(pgrep gvfsd-sftp)
gio mount sftp://127.0.0.1/   # fires mount-added → refresh; or lock/unlock the session
```

Measure shell responsiveness from another terminal:

```bash
timeout 5 gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.freedesktop.DBus.Peer.Ping
```

## Testing

- VM functional test on Ubuntu 24.04 / GNOME 46: extension ACTIVE, no crash, no JS errors.
- With the fix, 60/60 shell pings answered in 8–12 ms straight through a wedged-backend `mount-added`; the old code parks/blocks on the same trigger (instrumented per-probe timings confirm).
- `npm run lint` and `make clean build` pass at every commit in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/154)
<!-- Reviewable:end -->
